### PR TITLE
Fixed unused endpoint key str

### DIFF
--- a/examples/person_endpoint.py
+++ b/examples/person_endpoint.py
@@ -22,7 +22,7 @@ class Company(Base):
 
 if __name__ == '__main__':
     app = LightApi()
-    app.register({'/person': Person})
-    app.register({'/company': Company})
+    app.register({"person": Person})
+    app.register({"company": Company})
     app.run()
 

--- a/examples/person_endpoint.py
+++ b/examples/person_endpoint.py
@@ -19,10 +19,17 @@ class Company(Base):
     email = Column(String, unique=True)
     website = Column(String)
 
+class Customer(Base):
+    name = Column(String)
+    email = Column(String, unique=True)
+    address = Column(String)
 
 if __name__ == '__main__':
     app = LightApi()
-    app.register({"person": Person})
-    app.register({"company": Company})
+    # creates the API endpoints with the given keys
+    app.register({"person": Person, "company": Company})
+    # creates an API endpoint corresponding to the model name -> 'customer'
+    app.register({"": Customer})
+
     app.run()
 

--- a/lightapi/handlers.py
+++ b/lightapi/handlers.py
@@ -15,6 +15,7 @@ def create_handler(endpoint: str, model: Base) -> list:
     Returns:
         list: A list of aiohttp web routes for the specified model.
     """
+    endpoint = endpoint if len(endpoint) > 0 else model.__tablename__
     return [
         web.post(f"/{endpoint}/", CreateHandler(model)),
         web.get(f"/{endpoint}/", RetrieveAllHandler(model)),

--- a/lightapi/handlers.py
+++ b/lightapi/handlers.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 from aiohttp import web
 
 
-def create_handler(model: Base):
+def create_handler(endpoint: str, model: Base) -> list:
     """
     Creates a list of route handlers for the given model.
 
@@ -16,14 +16,14 @@ def create_handler(model: Base):
         list: A list of aiohttp web routes for the specified model.
     """
     return [
-        web.post(f'/{model.__tablename__}/', CreateHandler(model)),
-        web.get(f'/{model.__tablename__}/', RetrieveAllHandler(model)),
-        web.get(f'/{model.__tablename__}/{{id}}', ReadHandler(model)),
-        web.put(f'/{model.__tablename__}/{{id}}', UpdateHandler(model)),
-        web.delete(f'/{model.__tablename__}/{{id}}', DeleteHandler(model)),
-        web.patch(f'/{model.__tablename__}/{{id}}', PatchHandler(model)),
-        web.options(f'/{model.__tablename__}/', OptionsHandler(model)),
-        web.head(f'/{model.__tablename__}/', HeadHandler(model)),
+        web.post(f"/{endpoint}/", CreateHandler(model)),
+        web.get(f"/{endpoint}/", RetrieveAllHandler(model)),
+        web.get(f"/{endpoint}/{{id}}", ReadHandler(model)),
+        web.put(f"/{endpoint}/{{id}}", UpdateHandler(model)),
+        web.delete(f"/{endpoint}/{{id}}", DeleteHandler(model)),
+        web.patch(f"/{endpoint}/{{id}}", PatchHandler(model)),
+        web.options(f"/{endpoint}/", OptionsHandler(model)),
+        web.head(f"/{endpoint}/", HeadHandler(model)),
     ]
 
 

--- a/lightapi/lightapi.py
+++ b/lightapi/lightapi.py
@@ -33,9 +33,13 @@ class LightApi:
         except SQLAlchemyError as e:
             logging.error(f"Error creating tables: {e}")
 
-    def register(self, models: dict):
-        for path, model in models.items():
-            self.routes.extend(create_handler(model))
+    def register(self, models: dict[str, Base] | list[Base]) -> None:
+        if isinstance(models, dict):
+            for path, model in models.items():
+                self.routes.extend(create_handler(path, model))
+        elif isinstance(models, list):
+            for model in models:
+                self.routes.extend(create_handler(model.__tablename__, model))
 
     def run(self, host='0.0.0.0', port=8000):
         self.app.add_routes(self.routes)

--- a/lightapi/lightapi.py
+++ b/lightapi/lightapi.py
@@ -36,6 +36,7 @@ class LightApi:
     def register(self, models: dict[str, Base] | list[Base]) -> None:
         if isinstance(models, dict):
             for path, model in models.items():
+                path = path.removeprefix("/")
                 self.routes.extend(create_handler(path, model))
 
         elif isinstance(models, list):

--- a/lightapi/lightapi.py
+++ b/lightapi/lightapi.py
@@ -37,6 +37,7 @@ class LightApi:
         if isinstance(models, dict):
             for path, model in models.items():
                 self.routes.extend(create_handler(path, model))
+
         elif isinstance(models, list):
             for model in models:
                 self.routes.extend(create_handler(model.__tablename__, model))


### PR DESCRIPTION
When registering API endpoints, the key was not used as the endpoint.
Instead, the `model.__tablename__` value was used within the `create_handler` function and could not be changed by a user of LightAPI. 

The problem I see with that approach was that while the example shows that endpoints can be defined using a dictionary:
```python
app.register({"person": Person})
app.register({"custom-name": Company})
```
In this example, the endpoints `person` and `company` are defined with LightAPI as of now. The given endpoint key is ignored further on.

I added some logic that now uses the key, therefore the `Company` model is now using the endpoint `custom-name`.
Further on, the `/` at the beginning of the key string had to be omitted, otherwise the endpoint for `Person` would be `ip-address:8000//person/`.

Let me know if you have any questions/suggestions for this commit.

_Note: The current implementation requires a Python version >= 3.10 because of https://peps.python.org/pep-0604/. If you envision a larger support with other Python versions, let me know, I can change the code but this will result in less readability._
