### PR TITLE
ci: build Docker image in the release job (fix image not built on release)

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -133,6 +133,50 @@ jobs:
         git tag v${{ steps.update_version.outputs.new_version }}
         git push origin v${{ steps.update_version.outputs.new_version }}
     
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Wait for the release to be installable from PyPI
+      run: |
+        for i in $(seq 1 30); do
+          if curl -sfo /dev/null "https://pypi.org/pypi/lightapi/${{ steps.update_version.outputs.new_version }}/json"; then
+            echo "lightapi ${{ steps.update_version.outputs.new_version }} is available on PyPI"
+            exit 0
+          fi
+          echo "Waiting for PyPI to serve ${{ steps.update_version.outputs.new_version }}..."
+          sleep 10
+        done
+        echo "Timed out waiting for ${{ steps.update_version.outputs.new_version }} on PyPI" >&2
+        exit 1
+
+    - name: Build and push Docker image
+      # Built here, in the same job that publishes to PyPI, because a tag pushed
+      # by GITHUB_TOKEN does not trigger the docker-publish workflow (GitHub does
+      # not start workflows from events raised by the built-in token). Building
+      # inline guarantees iklob1/lightapi:<version> and :latest exist for every
+      # release, with the version just published.
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: true
+        build-args: |
+          LIGHTAPI_VERSION=${{ steps.update_version.outputs.new_version }}
+        tags: |
+          iklob1/lightapi:${{ steps.update_version.outputs.new_version }}
+          iklob1/lightapi:latest
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
     - name: Generate Release Notes
       id: release_notes
       run: |


### PR DESCRIPTION
## Problem

On release, `iklob1/lightapi:<version>` and `:latest` were never built automatically.

Root cause: `docker-publish.yml` triggers on `v*.*.*` tag pushes, but the release tag is pushed by the `deploy` job in `python-publish.yml` using the built-in `GITHUB_TOKEN`. GitHub does not start new workflow runs from events raised by `GITHUB_TOKEN` (recursion guard). So the tag push did not trigger the image build.

The only image that built was `:master`, from the merge commit, i.e. the pre-bump version. So the published `:latest` / `:<version>` never picked up new library code.

Observed on the 0.1.28 release: PyPI got 0.1.28, but no `:0.1.28` image existed until I triggered `docker-publish` manually with `gh workflow run "Publish Docker image" --ref v0.1.28`.

## Fix

Build and push the image in the same `deploy` job that publishes to PyPI, right after the tag is created, using the just-published version. This removes the dependency on cross-workflow triggering, so `:<version>` and `:latest` exist for every release. A short poll waits for the version to be installable from PyPI before building (the Dockerfile installs `lightapi==<version>` from PyPI).

`docker-publish.yml` is left unchanged: its tag / `master` / manual triggers still work for human-pushed tags and manual runs.

## Notes

- Uses the existing `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets.
- Cannot be verified locally (needs a real release run). Reasoned change; the YAML parses and step order is correct.
- Targets `dev`; takes effect on the next release after it reaches `master`.

## Alternatives considered

- PAT to push the tag so the tag event triggers docker-publish: needs a new secret and has PAT-scope/security cost.
- `workflow_run` trigger on the publish workflow: the checkout SHA is the pre-bump commit, so version detection would be wrong without extra ref juggling.
- `repository_dispatch` / `workflow_dispatch` from the publish job: relies on ambiguous GITHUB_TOKEN dispatch behavior.

Building inline is the most robust and self-contained.

https://claude.ai/code/session_01LWV5jPTwsAehx2rM7UZjtq