### PR TITLE
Release: CI fix so the Docker image builds on release (publishes next patch)

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -133,6 +133,50 @@ jobs:
         git tag v${{ steps.update_version.outputs.new_version }}
         git push origin v${{ steps.update_version.outputs.new_version }}
     
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Wait for the release to be installable from PyPI
+      run: |
+        for i in $(seq 1 30); do
+          if curl -sfo /dev/null "https://pypi.org/pypi/lightapi/${{ steps.update_version.outputs.new_version }}/json"; then
+            echo "lightapi ${{ steps.update_version.outputs.new_version }} is available on PyPI"
+            exit 0
+          fi
+          echo "Waiting for PyPI to serve ${{ steps.update_version.outputs.new_version }}..."
+          sleep 10
+        done
+        echo "Timed out waiting for ${{ steps.update_version.outputs.new_version }} on PyPI" >&2
+        exit 1
+
+    - name: Build and push Docker image
+      # Built here, in the same job that publishes to PyPI, because a tag pushed
+      # by GITHUB_TOKEN does not trigger the docker-publish workflow (GitHub does
+      # not start workflows from events raised by the built-in token). Building
+      # inline guarantees iklob1/lightapi:<version> and :latest exist for every
+      # release, with the version just published.
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: true
+        build-args: |
+          LIGHTAPI_VERSION=${{ steps.update_version.outputs.new_version }}
+        tags: |
+          iklob1/lightapi:${{ steps.update_version.outputs.new_version }}
+          iklob1/lightapi:latest
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
     - name: Generate Release Notes
       id: release_notes
       run: |


### PR DESCRIPTION
Promote dev to master. Brings the CI fix that builds iklob1/lightapi:<version> + :latest inside the PyPI publish job.

This release is the real test of that fix: the image should be built automatically by the publish job, with no manual `gh workflow run`.

https://claude.ai/code/session_01LWV5jPTwsAehx2rM7UZjtq